### PR TITLE
Fix database initialization error

### DIFF
--- a/database.py
+++ b/database.py
@@ -63,7 +63,7 @@ class Product(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     
     # JSON field for additional metadata
-    metadata = db.Column(JSONB)
+    product_metadata = db.Column(JSONB)
     
     # Indexes for better query performance
     __table_args__ = (
@@ -90,7 +90,7 @@ class Product(db.Model):
             'product_url': self.product_url,
             'last_updated': self.last_updated.isoformat(),
             'created_at': self.created_at.isoformat(),
-            'metadata': self.metadata
+            'metadata': self.product_metadata
         }
 
 class StockHistory(db.Model):


### PR DESCRIPTION
Rename `metadata` column to `product_metadata` in `Product` model to resolve SQLAlchemy reserved keyword conflict.

The `metadata` attribute name is reserved in SQLAlchemy's Declarative API, causing the database initialization to fail with an "Attribute name 'metadata' is reserved" error. Renaming the internal column to `product_metadata` resolves this conflict while keeping the external API response field as `metadata`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0de5f8de-2484-4a62-af84-86f31125e778">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0de5f8de-2484-4a62-af84-86f31125e778">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

