### PR TITLE
Fix werkzeug production error

### DIFF
--- a/api_app.py
+++ b/api_app.py
@@ -796,4 +796,4 @@ def create_app():
 
 if __name__ == '__main__':
     app = create_app()
-    socketio.run(app, debug=True, host='0.0.0.0', port=7000)
+    socketio.run(app, debug=True, host='0.0.0.0', port=7000, allow_unsafe_werkzeug=True)


### PR DESCRIPTION
Add `allow_unsafe_werkzeug=True` to `socketio.run()` to allow the development server to start in a production-like environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bc52e4a-228e-47f4-8c63-4bd14e96323d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4bc52e4a-228e-47f4-8c63-4bd14e96323d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

