### PR TITLE
Fix database connection error

### DIFF
--- a/api_app.py
+++ b/api_app.py
@@ -12,6 +12,7 @@ from flask_cors import CORS
 from flask_socketio import SocketIO, emit, join_room, leave_room
 from sqlalchemy import and_, or_, desc, func
 from sqlalchemy.orm import joinedload
+from sqlalchemy.pool import QueuePool
 import pandas as pd
 
 from database import db, Product, StockHistory, ScrapingLog, User
@@ -28,7 +29,7 @@ app.config['JWT_SECRET_KEY'] = JWT_SECRET_KEY
 app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
-    'poolclass': 'QueuePool',
+    'poolclass': QueuePool,
     'pool_size': 5,  # Reduced pool size to avoid threading issues
     'max_overflow': 10,  # Reduced max overflow
     'pool_pre_ping': True,


### PR DESCRIPTION
Correct SQLAlchemy `poolclass` configuration to fix `AttributeError`.

The `AttributeError: 'str' object has no attribute '__dict__'` occurred because SQLAlchemy's `poolclass` option was incorrectly configured with the string `'QueuePool'` instead of the actual `QueuePool` class object. This PR imports `QueuePool` and passes it directly, resolving the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ef27047-6990-49a1-a9d9-8560681d25df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ef27047-6990-49a1-a9d9-8560681d25df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

